### PR TITLE
Fix installation of [with-deps] extras (see #11)

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -20,7 +20,7 @@ its other dependencies run
 
 ::
 
-    pip install formasaurus[with-deps]
+    pip install formasaurus[with_deps]
 
 These packages may require extra steps to install, so the command above may
 fail. In this case install dependencies manually, on by one (follow their

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,13 @@ def get_version():
         return re.findall("__version__ = '([\d\.\w]+)'", f.read())[0]
 
 
+with_deps_extras = [
+    'scikit-learn >= 0.17',
+    'scipy',
+    'lxml',
+    'sklearn-crfsuite >= 0.3.1',
+]
+
 setup(
     name='formasaurus',
     version=get_version(),
@@ -36,12 +43,9 @@ setup(
         ],
     },
     extras_require={
-        'with-deps': [
-            'scikit-learn >= 0.17',
-            'scipy',
-            'lxml',
-            'sklearn-crfsuite >= 0.3.1',
-        ],
+        # Work around https://github.com/pypa/pip/issues/3032
+        'with-deps': with_deps_extras,
+        'with_deps': with_deps_extras,
         'annotation': [
             'ipython[notebook] >= 4.0',
             'ipywidgets',


### PR DESCRIPTION
Work around https://github.com/pypa/pip/issues/3032: add the same extras with and without dash.

I tested that it works as intended on ``pypi3032`` package: https://testpypi.python.org/pypi/pypi3032/0.2 works with ``with-deps``, and https://testpypi.python.org/pypi/pypi3032/0.1 does not.

This will simplify installation and testing for packages that depend on Formasaurus.