### PR TITLE
Fix "with-deps" in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,5 @@ commands=
     pip install -U wheel pip
     pip install numpy
     pip install scipy
-    pip install -e .[with-deps,annotation]
+    pip install -e .[with_deps,annotation]
     py.test --doctest-modules --cov=formasaurus --cov-report= {posargs: formasaurus tests}


### PR DESCRIPTION
~~Sorry for the noise - want to check build status without the change first (it fails locally but it might be my issue).~~ (travis-ci outsmarted me anyway).

pip 8.1.2 does not like the name ``with-deps`` even in ``pip install .[with-deps]`` context now, so fixing it there as well.